### PR TITLE
Fix API route exception: Remove intentional test error from /api/submit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# logs
+server.log

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -4,9 +4,6 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    // Throw an intentional exception
-    throw new Error("Intentional API route error - this is a test exception");
-
     // Log the form data
     console.log("Form submission received:", {
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Problem
The `/api/submit` endpoint was throwing an intentional test exception causing 500 errors:
```
Error: Intentional API route error - this is a test exception
```

## Solution
- Removed the intentional test exception from the POST handler
- The API route now properly processes form submissions and returns success responses
- Added `server.log` to `.gitignore` to prevent log files from being committed

## Testing
✅ Tested the API endpoint with valid data - returns 200 with success response
✅ Tested the API endpoint with invalid data - returns 400 with proper validation error
✅ Confirmed the form submission processing logic works as expected

## Changes
- `src/app/api/submit/route.ts`: Removed the intentional exception throw
- `.gitignore`: Added server.log to prevent log files from being committed

The API route now functions correctly and processes form submissions without throwing exceptions.

@sameelarif can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2ee8e192a3704f698e856feebd82bcdf)