### PR TITLE
Fix API submit route by removing intentional test exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# logs
+server.log
+
+# npm lock file (project uses pnpm)
+package-lock.json

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -4,9 +4,6 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    // Throw an intentional exception
-    throw new Error("Intentional API route error - this is a test exception");
-
     // Log the form data
     console.log("Form submission received:", {
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Problem
The `/api/submit` endpoint was throwing intentional test exceptions, causing all POST requests to return 500 errors with the message "Intentional API route error - this is a test exception".

## Solution
- Removed the intentional `throw new Error("Intentional API route error - this is a test exception")` statement from line 8 of `src/app/api/submit/route.ts`
- The API now properly processes form submissions and returns appropriate responses:
  - 200 status with success data for valid requests
  - 400 status with validation errors for invalid requests
- Updated `.gitignore` to exclude `server.log` and `package-lock.json` files

## Testing
- ✅ Tested with valid form data - returns 200 status with processed data
- ✅ Tested with invalid form data (missing required fields) - returns 400 status with validation error
- ✅ Verified proper logging functionality
- ✅ Confirmed no more 500 errors from the intentional exception

## Changes
- `src/app/api/submit/route.ts`: Removed intentional test exception
- `.gitignore`: Added server.log and package-lock.json entries

@sameelarif can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ff1742b622df46eca13e6f3bbe956b98)